### PR TITLE
Correct DNS settings in proxy-to-China mode

### DIFF
--- a/fancyss_arm/shadowsocks/ss/ssconfig.sh
+++ b/fancyss_arm/shadowsocks/ss/ssconfig.sh
@@ -666,22 +666,30 @@ create_dnsmasq_conf(){
 		do
 			detect_domain "$wan_white_domain"
 			if [ "$?" == "0" ];then
-				echo "$wan_white_domain" | sed "s/^/server=&\/./g" | sed "s/$/\/$CDN#53/g" >> /tmp/wblist.conf
-				echo "$wan_white_domain" | sed "s/^/ipset=&\/./g" | sed "s/$/\/white_list/g" >> /tmp/wblist.conf
+				# 回国模式下，用外国DNS，否则用中国DNS。
+				if [ "$ss_basic_mode" != "6" ];then
+					echo "$wan_white_domain" | sed "s/^/server=&\/./g" | sed "s/$/\/$CDN#53/g" >> /tmp/wblist.conf
+					echo "$wan_white_domain" | sed "s/^/ipset=&\/./g" | sed "s/$/\/white_list/g" >> /tmp/wblist.conf
+				else
+					echo "$wan_white_domain" | sed "s/^/server=&\/./g" | sed "s/$/\/$ss_direct_user/g" >> /tmp/wblist.conf
+					echo "$wan_white_domain" | sed "s/^/ipset=&\/./g" | sed "s/$/\/white_list/g" >> /tmp/wblist.conf
+				fi
 			else
 				echo_date ！！检测到域名白名单内的【"$wan_white_domain"】不是域名格式！！此条将不会添加！！
 			fi
 		done
 	fi
 	
-	# apple 和 microsoft不能走ss
-	echo "#for special site" >> /tmp/wblist.conf
-	for wan_white_domain2 in "apple.com" "microsoft.com"
-	do 
-		echo "$wan_white_domain2" | sed "s/^/server=&\/./g" | sed "s/$/\/$CDN#53/g" >> /tmp/wblist.conf
-		echo "$wan_white_domain2" | sed "s/^/ipset=&\/./g" | sed "s/$/\/white_list/g" >> /tmp/wblist.conf
-	done
-	
+	# 非回国模式下，apple 和 microsoft不能走ss
+	if [ "$ss_basic_mode" != "6" ];then
+		echo "#for special site" >> /tmp/wblist.conf
+		for wan_white_domain2 in "apple.com" "microsoft.com"
+		do 
+			echo "$wan_white_domain2" | sed "s/^/server=&\/./g" | sed "s/$/\/$CDN#53/g" >> /tmp/wblist.conf
+			echo "$wan_white_domain2" | sed "s/^/ipset=&\/./g" | sed "s/$/\/white_list/g" >> /tmp/wblist.conf
+		done
+	fi
+
 	# append black domain list, through ss
 	wanblackdomain=$(echo $ss_wan_black_domain | base64_decode)
 	if [ -n "$ss_wan_black_domain" ];then


### PR DESCRIPTION
The original implementation of this plugin doesn't work very well in the proxy-back-to-China mode due to the wrong logic of generating dnsmasq settings. 

- In this mode, a non-commie DNS (e.g. CloudFlare's 1.1.1.1 or Google's 8.8.8.8) should be used to resolve the whitelisted domains
- Apple/Microsoft was force whitelisted, which means some requests to Apple or Microsoft are using mainland Chinese CDNs. That's not good outside mainland China.

This pull request has solved the problem stated above.

原本的回国模式存在问题：

- dnsmasq设置生成的不正确，苹果和微软的网站被强行整上了国内的DNS解析，而不是境外的DNS；
- 之前的白名单全部由国内CDN解析，会导致境外误用了中国大陆的CDN，严重影响体验。

此版本已修复上述问题。