### PR TITLE
v2ray custom json configuration enhancement

### DIFF
--- a/fancyss_arm/shadowsocks/res/ss-menu.js
+++ b/fancyss_arm/shadowsocks/res/ss-menu.js
@@ -524,7 +524,7 @@ function openssHint(itemNum) {
 		statusmenu = "</br><font color='#CC0066'><b>1:不勾选（自动生成json）：</b></font>"
 		statusmenu += "</br>&nbsp;&nbsp;&nbsp;&nbsp;此方式只支持vmess作为传出协议，不支持sock，shadowsocks；提交后会根据你的配置自动生成v2ray的json配置。"
 		statusmenu += "</br></br><font color='#CC0066'><b>1:勾选（自定义json）：</b></font>"
-		statusmenu += "</br>&nbsp;&nbsp;&nbsp;&nbsp;此方式支持配置v2ray支持的所有传出协议，插件会取你的json的outbound部分，并自动配置透明代理和socks传进协议，以便在路由器上工作。"
+		statusmenu += "</br>&nbsp;&nbsp;&nbsp;&nbsp;此方式支持配置v2ray支持的所有传入传出协议，支持链式代理与反向代理，支持自定义路由与负载均衡。插件仅检查你的json的inbounds部分，并自动配置透明代理和socks传进协议，以便在路由器上工作。"
 		_caption = "使用json配置";
 	} else if (itemNum == 28) {
 		width = "750px";

--- a/fancyss_arm/shadowsocks/webs/Main_Ss_Content.asp
+++ b/fancyss_arm/shadowsocks/webs/Main_Ss_Content.asp
@@ -3401,7 +3401,9 @@ function set_cron(action) {
 																<th width="35%">v2ray json</th>
 																<td>
 																	<textarea placeholder="# 此处填入v2ray json，内容可以是标准的也可以是压缩的
-																	# 请保证你json内的outbound配置正确！！！
+																	# 请保证你json内的outbounds配置正确！！！
+																	# 如有自定义inbounds，请勿占用3333和23456端口！！！
+																	# 如有自定义routing且使用到了geoip/geosite，请自行下载对应的dat文件！
 																	# ------------------------------------
 																	# 同样支持vmess://链接填入，格式如下：
 																	vmess://ew0KICAidiI6ICIyIiwNCiAgInBzIjogIjIzMyIsDQogICJhZGQiOiAiMjMzLjIzMy4yMzMuMjMzIiwNCiAgInBvcnQiOiAiMjMzIiwNCiAgImlkIjogImFlY2EzYzViLTc0NzktNDFjMy1hMWUzLTAyMjkzYzg2Y2EzOCIsDQogICJhaWQiOiAiMjMzIiwNCiAgIm5ldCI6ICJ3cyIsDQogICJ0eXBlIjogIm5vbmUiLA0KICAiaG9zdCI6ICJ3d3cuMjMzLmNvbSIsDQogICJwYXRoIjogIi8yMzMiLA0KICAidGxzIjogInRscyINCn0=" rows="32" style="width:99%; font-family:'Lucida Console'; font-size:12px;background:#475A5F;color:#FFFFFF;" id="ss_node_table_v2ray_json" name="ss_node_table_v2ray_json" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" title=""></textarea>
@@ -3691,7 +3693,9 @@ function set_cron(action) {
 													<th width="35%">v2ray json</th>
 													<td>
 														<textarea  placeholder="# 此处填入v2ray json，内容可以是标准的也可以是压缩的
-																	# 请保证你json内的outbound配置正确！！！
+																	# 请保证你json内的outbounds配置正确！！！
+																	# 如有自定义inbounds，请勿占用3333和23456端口！！！
+																	# 如有自定义routing且使用到了geoip/geosite，请自行下载对应的dat文件！
 																	# ------------------------------------
 																	# 同样支持vmess://链接填入，格式如下：
 																	vmess://ew0KICAidiI6ICIyIiwNCiAgInBzIjogIjIzMyIsDQogICJhZGQiOiAiMjMzLjIzMy4yMzMuMjMzIiwNCiAgInBvcnQiOiAiMjMzIiwNCiAgImlkIjogImFlY2EzYzViLTc0NzktNDFjMy1hMWUzLTAyMjkzYzg2Y2EzOCIsDQogICJhaWQiOiAiMjMzIiwNCiAgIm5ldCI6ICJ3cyIsDQogICJ0eXBlIjogIm5vbmUiLA0KICAiaG9zdCI6ICJ3d3cuMjMzLmNvbSIsDQogICJwYXRoIjogIi8yMzMiLA0KICAidGxzIjogInRscyINCn0=" rows="40" style="width:99%; font-family:'Lucida Console'; font-size:12px;background:#475A5F;color:#FFFFFF;" id="ss_basic_v2ray_json" name="ss_basic_v2ray_json" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" title=""></textarea>


### PR DESCRIPTION
此PR只针对fancyss-arm，在NETGEAR R8000上测试通过。

修改日志：

 - 修改了ssconfig脚本中插件与自定义json配置合并的逻辑。
 - 修改了web页面的json部分的提示信息。
 - 修改了js menu中的提示信息。

原合并逻辑为使用用户提供的outbound部分，其他配置则会全部忽略。修改为默认使用用户提供的json文件，而插件会检查用户的inbounds的输入协议是否有占用3333/23456端口，如有则警告；然后插件会自动配置上dokodemo-door与socks的输入协议，并使用插件默认的日志配置。

这样做的好处是可以让高阶用户充分发挥v2ray的强大配置功能，例如自定义输入协议，自定义路由，多路负载均衡，链式代理等。