### PR TITLE
修复故障转移当前节点状态延时获取方法

### DIFF
--- a/fancyss_hnd/shadowsocks/scripts/ss_status_main.sh
+++ b/fancyss_hnd/shadowsocks/scripts/ss_status_main.sh
@@ -137,7 +137,7 @@ failover_check_3(){
 		return
 	fi
 
-	local OK_MARK=$(cat "$LOGFILE_F" | sed '/fancyss/d' | tail -n "$ss_failover_s3_1" | grep -E "200 OK"|sed 's/time=//g' | awk '{print $(NF-4)}' | awk '{sum+=$1} END {print sum/NR}' | awk '{printf "%.0f\n",$1}')
+	local OK_MARK=$(cat "$LOGFILE_F" | sed '/fancyss/d' | tail -n "$ss_failover_s3_1" | grep -E "200 OK" | grep -oe time=[0-9]* | sed 's/time=//g' | awk '{sum+=$1} END {print sum/NR}' | awk '{printf "%.0f\n",$1}')
 	#echo "$LOGTIME1 fancyss：前15次状态平均延迟：$OK_MARK ！"
 	if [ "$OK_MARK" -gt "$ss_failover_s3_2" ];then
 		failover_action 3 "$OK_MARK"


### PR DESCRIPTION
```
03-21 19:34:09 connected to xxxxxxxxxxxxx:80 time=265.26 ms 200 OK [上海-香港 01] 8
03-21 19:34:16 connected to xxxxxxxxxxxxx:80 time=507.47 ms 200 OK [上海-香港 01] 9
03-21 19:34:21 connected to xxxxxxxxxxxxx:80 time=277.69 ms 200 OK [上海-香港 01] 10
03-21 19:34:26 connected to xxxxxxxxxxxxx:80 time=518.21 ms 200 OK [上海-香港 01] 11
03-21 19:34:32 connected to xxxxxxxxxxxxx:80 time=1298.17 ms 200 OK [上海-香港 01] 12
03-21 19:34:40 connected to xxxxxxxxxxxxx:80 time=335.03 ms 200 OK [上海-香港 01] 13
03-21 19:34:45 connected to xxxxxxxxxxxxx:80 time=1338.25 ms 200 OK [上海-香港 01] 14
03-21 19:34:52 connected to xxxxxxxxxxxxx:80 time=582.90 ms 200 OK [上海-香港 01] 15
03-21 19:34:59 connected to xxxxxxxxxxxxx:80 time=1786.23 ms 200 OK [上海-香港 01] 16
03-21 19:35:07 connected to xxxxxxxxxxxxx:80 time=925.64 ms 200 OK [上海-香港 01] 17
```

旧代码获取的延时一直是 `200`，新代码使用 `time=` 关键字匹配，跟日志字段数结偶。