### PR TITLE
ss_pre_stop 不应该在启动的时候执行，只应该在关闭ss的时候执行

### DIFF
--- a/fancyss_hnd/shadowsocks/ss/ssconfig.sh
+++ b/fancyss_hnd/shadowsocks/ss/ssconfig.sh
@@ -2371,7 +2371,6 @@ disable_ss() {
 }
 
 apply_ss() {
-	ss_pre_stop
 	# now stop first
 	echo_date ======================= 梅林固件 - 【科学上网】 ========================
 	echo_date


### PR DESCRIPTION
否则会有报错。
我的场景是使用了iptables改变东西，如果开启的时候就执行，chain不存在就会报错。