### PR TITLE
bug修复 ssconfig.sh

### DIFF
--- a/fancyss/ss/ssconfig.sh
+++ b/fancyss/ss/ssconfig.sh
@@ -1417,7 +1417,7 @@ resolv_server_ip() {
 			case $? in
 			0)
 				echo_date "$(__get_type_abbr_name)服务器【${ss_basic_server}】的ip地址解析成功：${SERVER_IP}"
-				ss_basic_server="$SERVER_IP"
+				# ss_basic_server="$SERVER_IP"
 				ss_basic_server_ip="$SERVER_IP"
 				dbus set ss_basic_server_ip="$SERVER_IP"
 				;;


### PR DESCRIPTION
注释掉1420行，域名在端口复用的时候需要用于nginx分流，不能强制在配置文件按解析后的IP设置。