### PR TITLE
Bug修复，重点修复armv7版本前端崩溃

### DIFF
--- a/fancyss/webs/Module_shadowsocks.asp
+++ b/fancyss/webs/Module_shadowsocks.asp
@@ -368,11 +368,19 @@ function save() {
 	dbus["ss_basic_include"] = E("ss_basic_include").value.replace(pattern,"") || "";
 	// collect data from checkbox
 	for (var i = 0; i < params_check.length; i++) {
-		dbus[params_check[i]] = E(params_check[i]).checked ? '1' : '0';
+		if (E(params_check[i])) {
+			dbus[params_check[i]] = E(params_check[i]).checked ? '1' : '0';
+		}else{
+			dbus[params_check[i]] = '0';
+		}
 	}
 	// data need base64 encode, format b with plain text
 	for (var i = 0; i < params_base64.length; i++) {
-		dbus[params_base64[i]] = Base64.encode(E(params_base64[i]).value);
+		if (E(params_base64[i])) {
+			dbus[params_base64[i]] = Base64.encode(E(params_base64[i]).value);
+		}else{
+			dbus[params_base64[i]] = "";
+		}
 	}
 	// collect values in acl table
 	if(E("ACL_table")){
@@ -2744,7 +2752,7 @@ function generate_node_info() {
 					server_prot = json.outbounds.protocol;
 				}
 			}
-			obj["server"] = server_add;
+			obj["server"] = server_addr;
 			obj["protoc"] = server_prot;
 		}
 		if(db_ss[p + "_xray_use_json_" + idx] ==  "1"){
@@ -6924,7 +6932,7 @@ function reset_smartdns_conf(){
 																{ id:'ss_basic_udpoff', name:'ss_basic_udp_proxy', func:'u', type:'radio', suffix: '<a class="hintstyle" href="javascript:void(0);" onclick="openssHint(151)"><font color="#ffcc00">关闭</font></a>', value: 0},
 																{ id:'ss_basic_udpall', name:'ss_basic_udp_proxy', func:'u', type:'radio', suffix: '<a class="hintstyle" href="javascript:void(0);" onclick="openssHint(152)"><font color="#ffcc00">开启</font></a>', value: 1},
 																{ id:'ss_basic_udpgpt', name:'ss_basic_udp_proxy', func:'u', type:'radio', suffix: '<a class="hintstyle" href="javascript:void(0);" onclick="openssHint(153)"><font color="#ffcc00">仅chatgpt</font></a>', value: 2},
-															]},							//fancyss-hnd
+															]},
 															{ td: '<tr><td class="smth" style="font-weight: bold;" colspan="2">性能优化</td></tr>'},
 															{ title: 'ss/ssr/trojan开启多核心支持', id:'ss_basic_mcore', hint:'108', type:'checkbox', value:true},								//fancyss-hnd
 															{ title: 'ss/v2ray/xray开启tcp fast open', id:'ss_basic_tfo', type:'checkbox', value:false},										//fancyss-hnd


### PR DESCRIPTION
这个pr修复了几个前端代码中的bug
目前的自动编译系统对armv7并不是很友好，作为一个AC88U用户，更新3.2.6版本后前端整个崩溃了，一开始我以为是自己环境问题还双清了路由器，后来看issue发现是前端代码问题。
于是自己写了一个自用patch修复了armv7前端，附在这里
[Module_shadowsocks.asp.zip](https://github.com/hq450/fancyss/files/14174185/Module_shadowsocks.asp.zip)
然后想知道问题来源，就fork了仓库，看了下build前的代码，顺手修了几个问题开个pr，前两个问题在armv7版本上都会让插件不可用
1.给参数加了合法性校验，避免null参数保存不了改动
2.删除原6927行注释，推测这个//fancyss-hnd注释导致该行在编译armv7版本时被删除，导致前端代码崩溃
3.修正原2747行拼写错误