### PR TITLE
修复服务器ip变化重启触发功能、避免hysteria2多次运行

### DIFF
--- a/fancyss/scripts/ss_reboot_job.sh
+++ b/fancyss/scripts/ss_reboot_job.sh
@@ -3,6 +3,7 @@
 # fancyss script for asuswrt/merlin based router with software center
 
 source /koolshare/scripts/ss_base.sh
+source /koolshare/ss/ssconfig.sh
 ISP_DNS1=$(nvram get wan0_dns|sed 's/ /\n/g'|grep -v 0.0.0.0|grep -v 127.0.0.1|sed -n 1p)
 ISP_DNS2=$(nvram get wan0_dns|sed 's/ /\n/g'|grep -v 0.0.0.0|grep -v 127.0.0.1|sed -n 2p)
 IFIP_DNS1=`echo $ISP_DNS1|grep -E "([0-9]{1,3}[\.]){3}[0-9]{1,3}|:"`
@@ -65,94 +66,6 @@ set_ss_trigger_job(){
 	fi
 }
 
-#-------------------
-
-__valid_ip(){
-	# 验证是否为ipv4或者ipv6地址，是则正确返回，不是返回空值
-	local format_4=`echo "$1"|grep -Eo "([0-9]{1,3}[\.]){3}[0-9]{1,3}"`
-	local format_6=`echo "$1"|grep -Eo '^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*'`
-	if [ -n "$format_4" ] && [ -z "$format_6" ];then
-		echo "$format_4"
-		return 0
-	elif [ -z "$format_4" ] && [ -n "$format_6" ];then
-		echo "$format_6"
-		return 0
-	else
-		echo ""
-		return 1
-	fi
-}
-
-__get_server_resolver(){
-	local value_1="$ss_basic_server_resolver"
-	local value_2="$ss_basic_server_resolver_user"
-	local res
-	if [ "$value_1" == "1" ];then
-		if [ -n "$IFIP_DNS1" ];then
-			res="$ISP_DNS1"
-		else
-			res="114.114.114.114"
-		fi
-	fi
-	[ "$value_1" == "2" ] && res="223.5.5.5"
-	[ "$value_1" == "3" ] && res="223.6.6.6"
-	[ "$value_1" == "4" ] && res="114.114.114.114"
-	[ "$value_1" == "5" ] && res="114.114.115.115"
-	[ "$value_1" == "6" ] && res="1.2.4.8"
-	[ "$value_1" == "7" ] && res="210.2.4.8"
-	[ "$value_1" == "8" ] && res="117.50.11.11"
-	[ "$value_1" == "9" ] && res="117.50.22.22"
-	[ "$value_1" == "10" ] && res="180.76.76.76"
-	[ "$value_1" == "11" ] && res="119.29.29.29"
-	if [ "$value_1" == "12" ];then
-		if [ -n "$value_2" ];then
-			res=$(__valid_ip "$value_2")
-			[ -z "$res" ] && res="114.114.114.114"
-		else
-			res="114.114.114.114"
-		fi
-	fi
-	echo $res
-}
-
-__get_server_resolver_port(){
-	local port
-	if [ "$ss_basic_server_resolver" == "12" ];then
-		if [ -n "$ss_basic_server_resolver_user" ];then
-			port=`echo "$ss_basic_server_resolver_user"|awk -F"#|:" '{print $2}'`
-			[ -z "$port" ] && port="53"
-		else
-			port="53"
-		fi
-	else
-		port="53"
-	fi
-	echo $port
-}
-
-__resolve_ip(){
-	local domain1=`echo "$1"|grep -E "^https://|^http://|/"`
-	local domain2=`echo "$1"|grep -E "\."`
-	if [ -n "$domain1" ] || [ -z "$domain2" ];then
-		# not ip, not domain
-		echo ""
-		return 2
-	else
-		# domain format
-		SERVER_IP=`nslookup "$1" $(__get_server_resolver):$(__get_server_resolver_port) | sed '1,4d' | awk '{print $3}' | grep -v :|awk 'NR==1{print}' 2>/dev/null`
-		SERVER_IP=$(__valid_ip $SERVER_IP)
-		if [ -n "$SERVER_IP" ];then
-			# success resolved
-			echo "$SERVER_IP"
-			return 0
-		else
-			# resolve failed
-			echo ""
-			return 1
-		fi
-	fi
-}
-
 __get_type_abbr_name() {
 	case "$ss_basic_type" in
 		0)
@@ -172,100 +85,49 @@ __get_type_abbr_name() {
 
 check_ip_now(){
 	local HOST OLD_IP NEW_IP SERVER_INFO ADDR_INFO INFO_LINE tmp1
-	if [ "$ss_lb_enable" == "1" ] && [ `dbus get ss_basic_server | grep -o "127.0.0.1"` ] && [ `dbus get ss_basic_port` == `dbus get ss_lb_port` ];then
-		#负载均衡模式下检查/koolshare/configs/haproxy.cfg
-		logger "【科学上网插件触发重启功能】========================================================"
-		logger "【科学上网插件触发重启功能】：当前处于负载均衡状态，使用DNS:$(__get_server_resolver):$(__get_server_resolver_port)检查负载均衡节点IP是否更换..."
-		if [ -f /koolshare/configs/haproxy.cfg ] && [ -n `pidof haproxy` ];then
-			SERVER_INFO=$(cat /koolshare/configs/haproxy.cfg | grep -E "^\s\s\s\sserver"|sed 's/:/ /g'|awk '{print $2}')
-			ADDR_INFO=$(cat /koolshare/configs/haproxy.cfg | grep -E "^\s\s\s\sserver"|sed 's/:/ /g'|awk '{print $4}')
-			INFO_LINE=$(cat /koolshare/configs/haproxy.cfg | grep -E "^\s\s\s\sserver"|sed 's/:/ /g'|awk '{print $2" "$4}'|wc -l)
-			local i=1
-			local j=1
-			while [ $i -le $INFO_LINE ]
-			do
-				HOST=`echo $SERVER_INFO | cut -d " " -f $i`
-				OLD_IP=`echo $ADDR_INFO | cut -d " " -f $i`
-				tmp1=$(__valid_ip "$HOST")
-				if [ $? == 0 ];then
-					logger "【科学上网插件触发重启功能】：负载均衡节点：【$HOST】已经是IP格式！不进行任何操作！"
+	logger "【科学上网插件触发重启功能】========================================================"
+	logger "【科学上网插件触发重启功能】：使用DNS:$(__get_server_resolver):$(__get_server_resolver_port)检查$(__get_type_abbr_name)服务器IP是否更换..."
+	if [ -f "/tmp/ss_host.conf" ];then
+		HOST=`cat /tmp/ss_host.conf | cut -d "/" -f2`
+		OLD_IP=`cat /tmp/ss_host.conf | cut -d "/" -f3`
+		if [ -n "$HOST" ] && [ -n "$OLD_IP" ];then
+			__resolve_server_domain "$HOST"
+			case $? in
+			0)
+				# server is domain format and success resolved.
+				NEW_IP=$SERVER_IP
+				if [ "$OLD_IP"x == "$NEW_IP"x ];then
+					logger "【科学上网插件触发重启功能】：$(__get_type_abbr_name)服务器：【$HOST】的ip地址：【$OLD_IP】未发生变化，不进行任何操作！"
 				else
-					NEW_IP=$(__resolve_ip "$HOST")
-					case $? in
-					0)
-						# server is domain format and success resolved.
-						if [ "$OLD_IP"x == "$NEW_IP"x ];then
-							logger "【科学上网插件触发重启功能】：负载均衡节点：【$HOST】的ip地址：【$OLD_IP】未发生变化，不进行任何操作！"
-						else
-							logger "【科学上网插件触发重启功能】：负载均衡节点：$HOST的ip地址发生变化，旧ip：【$OLD_IP】，新ip：【$NEW_IP】"
-							let j+=1
-						fi
-						;;
-					1)
-						# server is domain format and failed to resolve.
-						logger "【科学上网插件触发重启功能】：负载均衡节点服务器：【$HOST】解析失败！不进行任何进一步操作！"
-						;;
-					2)
-						# server is not ip either domain!
-						logger "【科学上网插件触发重启功能】：负载均衡节点服务器：【$HOST】无法解析！因为它不是IP格式也不是域名格式！"
-						;;
-					esac
+					logger "【科学上网插件触发重启功能】：$(__get_type_abbr_name)服务器：【$HOST】的ip地址发生变化，旧ip：【$OLD_IP】，新ip：【$NEW_IP】"
+					#写入新的解析文件，用于下次比较
+					echo "address=/$HOST/$NEW_IP" > /tmp/ss_host.conf
+					logger "【科学上网插件触发重启功能】：重启插件，以应用新的ip"
+					start-stop-daemon -S -q -x /koolshare/ss/ssconfig.sh -- restart
 				fi
-				let i+=1
-			done
-
-			if [ $j -gt 1 ];then
-				logger "【科学上网插件触发重启功能】：重启负载均衡脚本，以应用新的ip"
-				sh /koolshare/scripts/ss_lb_config.sh
-			fi
+				;;
+			1)
+				# server is domain format and failed to resolve.
+				logger "【科学上网插件触发重启功能】：$(__get_type_abbr_name)服务器域名解析失败！！不进行任何进一步操作！"
+				;;
+			2)
+				# server is not ip either domain!
+				logger "【科学上网插件触发重启功能】：$(__get_type_abbr_name)服务器域名服务器：【$HOST】无法解析！因为它不是IP格式也不是域名格式！"
+				;;
+			esac
 		else
-			logger "【科学上网插件触发重启功能】：检测失败！可能是haproxy未运行导致？"
+			logger "【科学上网插件触发重启功能】：未找到你当前节点的$(__get_type_abbr_name)服务器地址，可能插件提交时未正确解析！"
+			logger "【科学上网插件触发重启功能】：请尝试直接使用ip地址作为$(__get_type_abbr_name)服务器地址！"
 		fi
-		logger "【科学上网插件触发重启功能】========================================================"
 	else
-		logger "【科学上网插件触发重启功能】========================================================"
-		logger "【科学上网插件触发重启功能】：使用DNS:$(__get_server_resolver):$(__get_server_resolver_port)检查$(__get_type_abbr_name)服务器IP是否更换..."
-		if [ -f "/tmp/ss_host.conf" ];then
-			HOST=`cat /tmp/ss_host.conf | cut -d "/" -f2`
-			OLD_IP=`cat /tmp/ss_host.conf | cut -d "/" -f3`
-			if [ -n "$HOST" ] && [ -n "$OLD_IP" ];then
-				NEW_IP=$(__resolve_ip "$HOST")
-				case $? in
-				0)
-					# server is domain format and success resolved.
-					if [ "$OLD_IP"x == "$NEW_IP"x ];then
-						logger "【科学上网插件触发重启功能】：$(__get_type_abbr_name)服务器：【$HOST】的ip地址：【$OLD_IP】未发生变化，不进行任何操作！"
-					else
-						logger "【科学上网插件触发重启功能】：$(__get_type_abbr_name)服务器：【$HOST】的ip地址发生变化，旧ip：【$OLD_IP】，新ip：【$NEW_IP】"
-						#写入新的解析文件，用于下次比较
-						echo "address=/$HOST/$NEW_IP" > /tmp/ss_host.conf
-						logger "【科学上网插件触发重启功能】：重启插件，以应用新的ip"
-						start-stop-daemon -S -q -x /koolshare/ss/ssconfig.sh -- restart
-					fi
-					;;
-				1)
-					# server is domain format and failed to resolve.
-					logger "【科学上网插件触发重启功能】：$(__get_type_abbr_name)服务器域名解析失败！！不进行任何进一步操作！"
-					;;
-				2)
-					# server is not ip either domain!
-					logger "【科学上网插件触发重启功能】：$(__get_type_abbr_name)服务器域名服务器：【$HOST】无法解析！因为它不是IP格式也不是域名格式！"
-					;;
-				esac
-			else
-				logger "【科学上网插件触发重启功能】：未找到你当前节点的$(__get_type_abbr_name)服务器地址，可能插件提交时未正确解析！"
-				logger "【科学上网插件触发重启功能】：请尝试直接使用ip地址作为$(__get_type_abbr_name)服务器地址！"
-			fi
+		if [ -n "$ss_basic_server" ];then
+			temp2=$(__valid_ip "$ss_basic_server")
+			logger "【科学上网插件触发重启功能】：当前$(__get_type_abbr_name)服务器地址已经是IP格式：$temp2！不进行任何操作！"
 		else
-			if [ -n "$ss_basic_server_ip" ];then
-				temp2=$(__valid_ip "$ss_basic_server_ip")
-				logger "【科学上网插件触发重启功能】：当前$(__get_type_abbr_name)服务器地址已经是IP格式：$temp2！不进行任何操作！"
-			else
-				logger "【科学上网插件触发重启功能】：未找到你当前节点的$(__get_type_abbr_name)服务器地址，可能已是IP格式！不进行任何操作！"
-			fi
+			logger "【科学上网插件触发重启功能】：未找到你当前节点的$(__get_type_abbr_name)服务器地址，可能已是IP格式！不进行任何操作！"
 		fi
-		logger "【科学上网插件触发重启功能】========================================================"
 	fi
+	logger "【科学上网插件触发重启功能】========================================================"
 }
 # -------------------
 

--- a/fancyss/ss/ssconfig.sh
+++ b/fancyss/ss/ssconfig.sh
@@ -4426,7 +4426,6 @@ start_hysteria2(){
 	else
 		env -i PATH=${PATH} QUIC_GO_DISABLE_ECN=true hysteria2 -c /koolshare/ss/hysteria2.yaml >/dev/null 2>&1 &
 	fi
-	run_bg hysteria2 -c /koolshare/ss/hysteria2.yaml
 	detect_running_status hysteria2
 }
 

--- a/fancyss/ss/ssconfig.sh
+++ b/fancyss/ss/ssconfig.sh
@@ -1119,7 +1119,9 @@ resolv_server_ip() {
 			case $? in
 			0)
 				echo_date "$(__get_type_abbr_name)服务器【${ss_basic_server}】的ip地址解析成功：${SERVER_IP}"
-				ss_basic_server="$SERVER_IP"
+				# 将ip解析结果写入ss_host.conf文件
+				echo "address=/${ss_basic_server}/${SERVER_IP}" >/tmp/ss_host.conf
+				echo_date "$(__get_type_abbr_name)服务器【${ss_basic_server}】的ip地址解析成功：${SERVER_IP}"
 				ss_basic_server_ip="$SERVER_IP"
 				dbus set ss_basic_server_ip="$SERVER_IP"
 				;;


### PR DESCRIPTION
修复服务器ip变化重启触发功能
- 使用`ssconfig.sh`中的`__get_server_resolver_port`和`__get_server_resolver`，因为`ss_reboot_job.sh`中的版本没有更新，不支持新加入的自动选择DNS功能
- 成功解析服务器ip后不执行`ss_basic_server="$SERVER_IP"` 而是将ip解析结果写入ss_host.conf文件
- 移除负载均衡、haproxy相关代码

避免hysteria2被多次执行
- 移除额外的`run_bg hysteria2 -c /koolshare/ss/hysteria2.yaml`