### PR TITLE
代理为回国模式时 允许ACL使用全局代理模式

### DIFF
--- a/fancyss/webs/Module_shadowsocks.asp
+++ b/fancyss/webs/Module_shadowsocks.asp
@@ -5138,6 +5138,7 @@ function refresh_acl_html() {
 		code += '<select id="ss_acl_mode_' + ac["acl_node"] + '" name="ss_acl_mode_' + ac["acl_node"] + '" style="width:140px;margin:0px 0px 0px 2px;" class="sel_option" onchange="set_mode_2(this);">';
 		if ($("#ss_basic_mode").val() == 6) {
 			code += '<option value="0">不通过代理</option>';
+			code += '<option value="5">全局代理模式</option>';
 			code += '<option value="6">回国模式</option>';
 		} else {
 			code += '<option value="0">不通过代理</option>';


### PR DESCRIPTION
代理是回国模式时，ACL中使用全局模式应该是一个合理的use case。

在代理回国模式/ACL设置全局模式时 首次添加能够正确保存acl信息到dbus
但在`refresh_acl_html`时加载已经存储的acl信息 
```
if ($("#ss_basic_mode").val() == 6) {
			code += '<option value="0">不通过代理</option>';
			code += '<option value="5">全局代理模式</option>';
			code += '<option value="6">回国模式</option>';
		}
```
导致html element里的ACL table没有正确加载全局代理的option

此时再重启插件就会导致`save()`时 `dbus["ss_acl_mode_" + rowid] = E("ss_acl_mode_" + rowid).value;`拿到一个空值 导致`ss_acl_mode`被从dbus中移除，ACL不生效
