### PR TITLE
修复“访问控制”栏目下，ip输入框因长度控制导致部分CIDR无法输入

### DIFF
--- a/fancyss/webs/Module_shadowsocks.asp
+++ b/fancyss/webs/Module_shadowsocks.asp
@@ -4961,7 +4961,7 @@ function refresh_acl_html() {
 	code += '<tr>'
 	// ip addr
 	code += '<td width="23%">'
-	code += '<input type="text" maxlength="15" class="input_ss_table" id="ss_acl_ip" align="left" style="float:left;width:110px;margin-left:16px;text-align:center" autocomplete="off" onClick="hideClients_Block();" autocorrect="off" autocapitalize="off">'
+	code += '<input type="text" maxlength="18" class="input_ss_table" id="ss_acl_ip" align="left" style="float:left;width:110px;margin-left:16px;text-align:center" autocomplete="off" onClick="hideClients_Block();" autocorrect="off" autocapitalize="off">'
 	code += '<img id="pull_arrow" height="14px;" src="/res/arrow-down.gif" align="right" onclick="pullLANIPList(this);" title="<#select_IP#>">'
 	code += '<div id="ClientList_Block" class="clientlist_dropdown" style="margin-left:2px;margin-top:25px;"></div>'
 	code += '</td>'


### PR DESCRIPTION
场景如下：
1、华硕路由器的本地内网为192.168.50.0/24网段
2、华硕的访客网络为192.168.100.0/24网段
希望通过fancyss，使所有访客网络走代理，其他网络不走代理。但因为"访问控制"栏目下的IP输入框“15”长度的限制，导致192.168.100.0/24输入失败。因此提交改动，支持所有ipv4网段的CIDR输入