### PR TITLE
fix: 更新订阅链接时，支持带空格的UA

### DIFF
--- a/fancyss/scripts/ss_node_subscribe.sh
+++ b/fancyss/scripts/ss_node_subscribe.sh
@@ -6543,21 +6543,21 @@ download_by_curl(){
 	local UA=$(get_ua)
 	if [ -n "${UA}" ];then
 		echo_date "🪧使用UA：$UA"
-		local UA_ARG="--user-agent ${UA}"
+		set -- --user-agent "${UA}"
 	else
 		echo_date "🪧使用UA：curl"
-		local UA_ARG=""
+		set --
 	fi
 
 	if [ ! -L "/tmp/curl-update" ];then
 		ln -sf /koolshare/bin/curl-fancyss /tmp/curl-subscribe
 	fi
-	
+
 	if [ "${SUB_BY_PROXY}" == "0" ]; then
 		# 先直连下载
 		echo_date "➡️通过本地网络直连下载订阅..."
 		rm -f "${header_file}" >/dev/null 2>&1
-		run /tmp/curl-subscribe -sSk -L ${UA_ARG} -D "${header_file}" --connect-timeout 5 -m 5 --retry 3 --retry-delay 1 "${url_encode}" 2>/dev/null >${DIR}/sub_file_encode_${SUB_LINK_HASH:0:4}.txt
+		run /tmp/curl-subscribe -sSk -L "$@" -D "${header_file}" --connect-timeout 5 -m 5 --retry 3 --retry-delay 1 "${url_encode}" 2>/dev/null >${DIR}/sub_file_encode_${SUB_LINK_HASH:0:4}.txt
 		if [ "$?" == "0" ]; then
 			return 0
 		fi
@@ -6568,7 +6568,7 @@ download_by_curl(){
 		if [ -n "${SOCKS5_OPEN}" ];then
 			echo_date "✈️使用当前$(get_type_name "$(sub_get_node_field_plain "${CURR_NODE}" type)")节点：[$(sub_get_node_field_plain "${CURR_NODE}" name)]提供的网络下载..."
 			rm -f "${header_file}" >/dev/null 2>&1
-			run /tmp/curl-subscribe -sSk -L ${UA_ARG} -D "${header_file}" --connect-timeout 5 -m 5 -x socks5h://127.0.0.1:23456 --retry 3 --retry-delay 1 "${url_encode}" 2>/dev/null >${DIR}/sub_file_encode_${SUB_LINK_HASH:0:4}.txt
+			run /tmp/curl-subscribe -sSk -L "$@" -D "${header_file}" --connect-timeout 5 -m 5 -x socks5h://127.0.0.1:23456 --retry 3 --retry-delay 1 "${url_encode}" 2>/dev/null >${DIR}/sub_file_encode_${SUB_LINK_HASH:0:4}.txt
 			return $?
 		else
 			echo_date "⚠️当前$(get_type_name "$(sub_get_node_field_plain "${CURR_NODE}" type)")节点工作异常，结束curl订阅下载！"
@@ -6581,7 +6581,7 @@ download_by_curl(){
 			local EXT_ARG="-x socks5h://127.0.0.1:23456"
 			echo_date "✈️使用当前$(get_type_name "$(sub_get_node_field_plain "${CURR_NODE}" type)")节点：[$(sub_get_node_field_plain "${CURR_NODE}" name)]提供的网络下载..."
 			rm -f "${header_file}" >/dev/null 2>&1
-			run /tmp/curl-subscribe -sSk -L ${UA_ARG} -D "${header_file}" --connect-timeout 5 -m 5 -x socks5h://127.0.0.1:23456 --retry 3 --retry-delay 1 "${url_encode}" 2>/dev/null >${DIR}/sub_file_encode_${SUB_LINK_HASH:0:4}.txt
+			run /tmp/curl-subscribe -sSk -L "$@" -D "${header_file}" --connect-timeout 5 -m 5 -x socks5h://127.0.0.1:23456 --retry 3 --retry-delay 1 "${url_encode}" 2>/dev/null >${DIR}/sub_file_encode_${SUB_LINK_HASH:0:4}.txt
 			return $?
 		else
 			local EXT_ARG=""
@@ -6592,7 +6592,7 @@ download_by_curl(){
 		# 直连下载
 		echo_date "⬇️使用常规网络下载..."
 		rm -f "${header_file}" >/dev/null 2>&1
-		run /tmp/curl-subscribe -sSk -L ${UA_ARG} -D "${header_file}" --connect-timeout 5 -m 5 --retry 3 --retry-delay 1 "${url_encode}" 2>/dev/null >${DIR}/sub_file_encode_${SUB_LINK_HASH:0:4}.txt
+		run /tmp/curl-subscribe -sSk -L "$@" -D "${header_file}" --connect-timeout 5 -m 5 --retry 3 --retry-delay 1 "${url_encode}" 2>/dev/null >${DIR}/sub_file_encode_${SUB_LINK_HASH:0:4}.txt
 		return $?
 	fi
 }


### PR DESCRIPTION
  ## Summary                                                                                    
  - `download_by_curl` 把 UA 拼进 `UA_ARG` 后以不带引号的形式展开，                             
    ClashX 这类含空格/括号的 UA 会被 word-split 成多个 token，
    真正发出去的 `User-Agent` 只剩首个 token，其余碎片被 curl 当成                              
    额外 URL 请求，导致订阅更新 404。                                                           
  - 改用位置参数承载：`set -- --user-agent "${UA}"` / `set --`，                                
    在 curl 调用处用 `"$@"` 展开，保证 UA 作为单个完整参数传入。                                
  - `url_encode` 在 `set --` 之前已存入局部变量，订阅链接不会丢。                               
  - `download_by_wget` 存在同样 bug，本 PR 暂不一并修改，先验证 curl 路径。                     
                                                                                                
  ## Test plan                                                                                  
  - [ ] 路由器覆盖 `/koolshare/scripts/ss_node_subscribe.sh` 后，在 Web UI 触发"更新订阅"       
  - [ ] 日志中 `🪧 使用UA：` 完整打印 `ClashX/1.125.0 (com.west2online.ClashX; build:1.125.0;    
  macOS 26.3.1) Alamofire/5.11.2`                                                               
  - [ ] 订阅返回不再是 404，节点能正常下发       