### PR TITLE
fix: 移除重复刷新导致的专属 DNS 文件清理

### DIFF
--- a/fancyss/ss/ssconfig.sh
+++ b/fancyss/ss/ssconfig.sh
@@ -1126,7 +1126,6 @@ refresh_node_direct_domain_file() {
 	fss_refresh_node_direct_cache
 	fss_airport_dns_override_load >/dev/null 2>&1 || true
 	if [ "${AIRPORT_DNS_ACTIVE}" = "1" ];then
-		fss_refresh_airport_special_runtime_domain_files >/dev/null 2>&1 || true
 		if [ -s "${FSS_NODE_DIRECT_RUNTIME_OTHER_FILE}" ];then
 			cp -f "${FSS_NODE_DIRECT_RUNTIME_OTHER_FILE}" "${FSS_NODE_DIRECT_RUNTIME_FILE}"
 		else


### PR DESCRIPTION
`fss_airport_dns_override_load` 已完成节点域名和专属 DNS 主机运行时文件的刷新。随后再次刷新节点域名会执行清理，删除刚生成的专属 DNS 主机文件，导致 SmartDNS 缺少引导解析规则。

如果不修复的话，nexitally的anytls订阅直接没法用。