### PR TITLE
fix: fancyss_hnd_v8_full 3.5.30 在 BE88U(3006.102.4) 上因 netstat -nlp 无进程名误判 xray 启动失败

### DIFF
--- a/fancyss/scripts/ss_base.sh
+++ b/fancyss/scripts/ss_base.sh
@@ -811,6 +811,16 @@ detect_running_status3(){
 		usleep 100000
 		i=$(($i - 1))
 		RET=$(netstat -nlp 2>/dev/null|grep -Ew "${PORT}"|grep -Eo "${BINNAME}"|head -n1)
+		# fallback for firmwares where netstat -nlp doesn't expose process names
+		if [ -z "${RET}" ]; then
+			local _pid
+			_pid="$(pidof ${BINNAME} 2>/dev/null)"
+			if [ -n "${_pid}" ]; then
+				RET="${BINNAME}"
+			elif netstat -an 2>/dev/null | grep -E ":${PORT}\b" >/dev/null 2>&1; then
+				RET="listen"
+			fi
+		fi
 		if [ "$i" -lt 1 ]; then
 			echo_date "$1进程启动失败，请检查你的配置！"
 			#return 1


### PR DESCRIPTION
## 背景说明

在部分固件环境中（已在 ASUS RT-BE88U，固件 3006.102.4 复现），`netstat -nlp` 可能无法稳定返回进程名。  
当前 fancyss 中，`detect_running_status3` 依赖 `netstat -nlp` 同时匹配端口和进程名，因此会出现误判：

- Xray 实际已成功启动；
- 但启动检测未命中；
- 插件最终提示“xray进程启动失败，请检查你的配置！”并自动关闭。

## 影响版本

- 插件版本：`[fancyss_hnd_v8_full] 3.5.30`
- 路由器：ASUS RT-BE88U
- 固件版本：3006.102.4

## 变更内容

对 `detect_running_status3` 增加回退检测逻辑（保留原有逻辑优先级）：

1. 先按原逻辑使用 `netstat -nlp` 检测；
2. 若未命中，回退使用 `pidof <BINNAME>` 检测进程是否存在；
3. 若仍未命中，再回退使用 `netstat -an` 检测目标端口是否存在。

这样可兼容 `netstat -nlp` 不暴露进程名的环境，避免误判启动失败。

## 验证结果

修复前：
- 配置测试结果为 `Configuration OK.`
- Xray 仅输出 Warning，无致命报错
- 插件仍误判启动失败并关闭

修复后：
- 插件可正常完成启动流程
- `pidof xray` 可返回有效 PID
- 代理出口检测与规则加载流程正常