### PR TITLE
fix: 清理 chng_hosts 行末句点，避免 chinadns-ng 启动失败

### DIFF
--- a/fancyss/ss/ssconfig.sh
+++ b/fancyss/ss/ssconfig.sh
@@ -2697,7 +2697,7 @@ start_chinadns_ng(){
 
 	# for hosts file
 	cp -rf /tmp/etc/hosts /tmp/etc/chng_hosts
-	sed -i -e 's/\.[[:space:]]/ /g' -e 's/\.$//' /etc/chng_hosts
+	sed -i -e 's/\.[[:space:]]/ /g' -e 's/\.$//' /tmp/etc/chng_hosts
 	
 	cat >>"/tmp/chinadns_ng.conf" <<-EOF
 	
@@ -2705,7 +2705,7 @@ start_chinadns_ng(){
 		filter-qtype 64,65
 
 		# hosts
-		hosts /etc/chng_hosts
+		hosts /tmp/etc/chng_hosts
 		
 		# dns 缓存
 		cache 8192

--- a/fancyss/ss/ssconfig.sh
+++ b/fancyss/ss/ssconfig.sh
@@ -2697,7 +2697,7 @@ start_chinadns_ng(){
 
 	# for hosts file
 	cp -rf /tmp/etc/hosts /tmp/etc/chng_hosts
-	sed -i 's/\.[[:space:]]/ /g' /etc/chng_hosts
+	sed -i -e 's/\.[[:space:]]/ /g' -e 's/\.$//' /etc/chng_hosts
 	
 	cat >>"/tmp/chinadns_ng.conf" <<-EOF
 	


### PR DESCRIPTION
## 问题

ASUSWRT/Merlin 的 DHCP 静态主机条目可能在 `/tmp/etc/hosts` 中生成以句点结尾的名称，例如：

```text
192.0.2.10 client-host.
```

FancySS 将该文件复制为 `/etc/chng_hosts` 后交给 chinadns-ng。当前清洗规则只处理句点后仍有空白字符的情况，遗漏位于行末的句点。chinadns-ng 随后报错并退出：

```text
[local_rr.zig:110 add_ip] invalid domain: 'client-host.'
[opt.zig:552 opt_hosts] failed to load hosts: '/etc/chng_hosts'
```

启动脚本最终只能观察到 chinadns-ng 进程启动失败。

## 修复

在现有 hosts 清洗命令中增加 `s/\.$//`，同时覆盖：

- 句点后有空白字符的主机名
- 位于行末的主机名

## 验证

- `sh -n fancyss/ss/ssconfig.sh` 通过
- 测试包含行末句点、同一行多个带句点别名和正常条目的 hosts 文件，输出符合预期
- 手动复现中，原始 hosts 条目稳定触发 chinadns-ng 退出；删除行末句点后，chinadns-ng 完成初始化并持续运行

所有地址、主机名和日志内容均使用通用占位示例。
